### PR TITLE
Upgrading MariaDB to the latest stable version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   mariadb:
-    image: 'bitnami/mariadb:10.1'
+    image: 'bitnami/mariadb:10.4'
     environment:
       - MARIADB_USER=bn_moodle
       - MARIADB_DATABASE=bitnami_moodle


### PR DESCRIPTION

Upgrading MariaDB to the latest stable version

**Benefits**

MariaDB 10.4 has a lot of benefits in the latest stable versions in compared with the 10.1 version. For more details, [please go here](https://mariadb.com/kb/en/changes-improvements-in-mariadb-104/)

**Possible drawbacks**

There isn't any trouble for this, at least not officially.

