### PR TITLE
Change charset and collation to utf8mb4

### DIFF
--- a/3/debian-10/docker-compose.yml
+++ b/3/debian-10/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
       - MARIADB_USER=bn_moodle
       - MARIADB_DATABASE=bitnami_moodle
+      - MARIADB_CHARACTER_SET=utf8mb4
+      - MARIADB_COLLATE=utf8mb4_unicode_ci
     volumes:
       - 'mariadb_data:/bitnami/mariadb'
   moodle:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
       - MARIADB_USER=bn_moodle
       - MARIADB_DATABASE=bitnami_moodle
+      - MARIADB_CHARACTER_SET=utf8mb4
+      - MARIADB_COLLATE=utf8mb4_unicode_ci
     volumes:
       - 'mariadb_data:/bitnami/mariadb'
   moodle:


### PR DESCRIPTION
**Description of the change**

Change charset and collation to utf8mb4 to support emoji's and satisfy the pre-checks on the plugin installation process.

**Benefits**

- Follow Moodle recommendation https://docs.moodle.org/310/en/MySQL_full_unicode_support
- Emoji support

**Possible drawbacks**

Unknown.

**Applicable issues**

None.

**Additional information**

None.
