### PR TITLE
Update libmoodle.sh

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -310,7 +310,7 @@ moodle_upgrade() {
         "--allow-unstable"
     )
     am_i_root && moodle_upgrade_args=("gosu" "$WEB_SERVER_DAEMON_USER" "${moodle_upgrade_args[@]}")
-    debug_execute "${moodle_install_args[@]}"
+    debug_execute "${moodle_upgrade_args[@]}"
     popd >/dev/null
 }
 


### PR DESCRIPTION
fixes https://github.com/bitnami/bitnami-docker-moodle/issues/166


**Description of the change**

fixes moodle_update to call the upgrade command instead of the install command

**Benefits**

installation works again

**Possible drawbacks**

none

**Applicable issues**

none

**Additional information**

none

