### PR TITLE
func(.env): Add the ability to specify how frequently the cron.php sc…

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -194,7 +194,7 @@ EOF
     # Ensure Moodle cron jobs are created when running setup with a root user
     local -a cron_cmd=("${PHP_BIN_DIR}/php" "${MOODLE_BASE_DIR}/admin/cli/cron.php")
     if am_i_root; then
-        generate_cron_conf "moodle" "${cron_cmd[*]} > /dev/null 2>> ${MOODLE_DATA_DIR}/moodle-cron.log" --run-as "$WEB_SERVER_DAEMON_USER" --schedule "*/1 * * * *"
+        generate_cron_conf "moodle" "${cron_cmd[*]} > /dev/null 2>> ${MOODLE_DATA_DIR}/moodle-cron.log" --run-as "$WEB_SERVER_DAEMON_USER" --schedule "*/${MOODLE_CRON_MINUTES} * * * *"
     else
         warn "Skipping cron configuration for Moodle because of running as a non-root user"
     fi

--- a/3/debian-10/rootfs/opt/bitnami/scripts/moodle-env.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/moodle-env.sh
@@ -112,3 +112,4 @@ export MOODLE_DATABASE_PASSWORD="${MOODLE_DATABASE_PASSWORD:-}" # only used duri
 export PHP_DEFAULT_MEMORY_LIMIT="256M" # only used at build time
 
 # Custom environment variables may be defined below
+export MOODLE_CRON_MINUTES="${MOODLE_CRON_MINUTES:-1}" # How frequently to run the moodle cron job.  Default to 1 minutes


### PR DESCRIPTION
Specify how frequently cron.ph should be running by adding a MOODLE_CRON_MINUTES variable that defaults to 1 (minute) with the ability to override this value from the environment variables in your docker-compose.yml file.

Changing it to run e.g. every 5 minutes would see an entry like this in docker-compose.yml:
```
      - MOODLE_CRON_MINUTES=5
```