### PR TITLE
Moodle cron can be disabled

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -194,9 +194,11 @@ EOF
     # Ensure Moodle cron jobs are created when running setup with a root user
     local -a cron_cmd=("${PHP_BIN_DIR}/php" "${MOODLE_BASE_DIR}/admin/cli/cron.php")
     if am_i_root; then
-        if [ ${MOODLE_CRON_MINUTES} -gt 0 ]; then generate_cron_conf "moodle" "${cron_cmd[*]} > /dev/null 2>> ${MOODLE_DATA_DIR}/moodle-cron.log" --run-as "$WEB_SERVER_DAEMON_USER" --schedule "*/${MOODLE_CRON_MINUTES} * * * *"
-    else if
-        if [ ${MOODLE_CRON_MINUTES} -eq 0 ]; then  warn "Skipping cron configuration for Moodle because MOODLE_CRON_MINUTES is set to 0"
+        if [ ${MOODLE_CRON_MINUTES} -gt 0 ]; then 
+            generate_cron_conf "moodle" "${cron_cmd[*]} > /dev/null 2>> ${MOODLE_DATA_DIR}/moodle-cron.log" --run-as "$WEB_SERVER_DAEMON_USER" --schedule "*/${MOODLE_CRON_MINUTES} * * * *"
+        else
+            warn "Skipping cron configuration for Moodle because MOODLE_CRON_MINUTES is set to 0"
+        fi
     else
         warn "Skipping cron configuration for Moodle because of running as a non-root user"
     fi

--- a/3/debian-10/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -194,7 +194,9 @@ EOF
     # Ensure Moodle cron jobs are created when running setup with a root user
     local -a cron_cmd=("${PHP_BIN_DIR}/php" "${MOODLE_BASE_DIR}/admin/cli/cron.php")
     if am_i_root; then
-        generate_cron_conf "moodle" "${cron_cmd[*]} > /dev/null 2>> ${MOODLE_DATA_DIR}/moodle-cron.log" --run-as "$WEB_SERVER_DAEMON_USER" --schedule "*/${MOODLE_CRON_MINUTES} * * * *"
+        if [ ${MOODLE_CRON_MINUTES} -gt 0 ]; then generate_cron_conf "moodle" "${cron_cmd[*]} > /dev/null 2>> ${MOODLE_DATA_DIR}/moodle-cron.log" --run-as "$WEB_SERVER_DAEMON_USER" --schedule "*/${MOODLE_CRON_MINUTES} * * * *"
+    else if
+        if [ ${MOODLE_CRON_MINUTES} -eq 0 ]; then  warn "Skipping cron configuration for Moodle because MOODLE_CRON_MINUTES is set to 0"
     else
         warn "Skipping cron configuration for Moodle because of running as a non-root user"
     fi

--- a/3/debian-10/rootfs/opt/bitnami/scripts/moodle-env.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/moodle-env.sh
@@ -50,6 +50,7 @@ moodle_env_vars=(
     SMTP_PROTOCOL
     MARIADB_HOST
     MARIADB_PORT_NUMBER
+    MOODLE_CRON_MINUTES
 )
 for env_var in "${moodle_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Available environment variables:
 - `MOODLE_EMAIL`: Moodle application email. Default: **user@example.com**
 - `MOODLE_SITE_NAME`: Moodle site name. Default: **New Site**
 - `MOODLE_SKIP_BOOTSTRAP`: Do not initialize the Moodle database for a new deployment. This is necessary in case you use a database that already has Moodle data. Default: **no**
+- `MOODLE_CRON_MINUTES`: Moodle maintenance cron frequency (in minutes). 0=Disabled. Default: **1**
 
 ##### Use an existing database
 


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Moodle maintenance cron task frequency can be set or completely disabled.

<!-- Describe the scope of your change - i.e. what the change does. -->

**Benefits**

PR #174 added the ability to set Moodle maintenance cron task frequency using env variable MOODLE_CRON_MINUTES with an integer number that states the frequency in minutes. Now it is also possible to set it to zero (0) to completely disable it. 
This makes it possible to use external tools to manage it (separate container, external webservice or web call): this is especially useful when scaling the number of Moodle containers (avoiding multiple execution of the cron task inside different containers)

**Applicable issues**

Initial issue is described in #173 

**Additional information**

Updated logic in code and documented the parameter in Readme