### PR TITLE
modified ports mapped for moodle

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
   moodle:
     image: docker.io/bitnami/moodle:3
     ports:
-      - '80:8080'
-      - '443:8443'
+      - '8080:8080'
+      - '8443:8443'
     environment:
       - MOODLE_DATABASE_HOST=mariadb
       - MOODLE_DATABASE_PORT_NUMBER=3306


### PR DESCRIPTION
port mapping in moodle i.e. `80:8080` & `443:8443` gives error 
```
ERROR: for ubuntu_moodle_1  Cannot start service moodle: driver failed programming external connectivity on endpoint ubuntu_moodle_1 (47d1ae5898de8163c20feb8fead9640017c842be84e91fd1143706560276b5ae): Error starting userland proxy: listen tcp4 0.0.0.0:80: bind: address already in use
```
```
ERROR: for moodle  Cannot start service moodle: driver failed programming external connectivity on endpoint ubuntu_moodle_1 (47d1ae5898de8163c20feb8fead9640017c842be84e91fd1143706560276b5ae): Error starting userland proxy: listen tcp4 0.0.0.0:80: bind: address already in use
```

therefore, I modified them to  '8080:8080' & '8443:8443' and it worked after these changes. 
Thank you for your code, its the only working docker-compose file on the internet.
