### PR TITLE
Fix: $CFG->reverseproxy is not configurable

### DIFF
--- a/3/debian-10/rootfs/opt/bitnami/scripts/libmoodle.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/libmoodle.sh
@@ -51,6 +51,11 @@ moodle_validate() {
             print_validation_error "An invalid port was specified in the environment variable ${port_var}: ${err}."
         fi
     }
+    check_yes_no_value() {
+        if ! is_yes_no_value "${!1}" && ! is_true_false_value "${!1}"; then
+            print_validation_error "The allowed values for ${1} are: yes no"
+        fi
+    }
 
     # Validate credentials
     if is_boolean_yes "$ALLOW_EMPTY_PASSWORD"; then
@@ -80,6 +85,10 @@ moodle_validate() {
 
     # Check that the web server is properly set up
     web_server_validate || print_validation_error "Web server validation failed"
+
+    # Check support for reverseproxy and sslproxy feature
+    check_yes_no_value "MOODLE_REVERSEPROXY"
+    check_yes_no_value "MOODLE_SSLPROXY"
 
     return "$error_code"
 }
@@ -357,21 +366,9 @@ if (isset(\$_SERVER['HTTPS']) \&\& \$_SERVER['HTTPS'] == 'on') {\\
 moodle_configure_reverseproxy() {
 
     # Checking the reverseproxy setting values
-    if ! is_empty_value "$MOODLE_REVERSEPROXY"; then
-        if [[ "$MOODLE_REVERSEPROXY" == "true" ]]; then
-            echo "\$CFG->reverseproxy = true;" >> "$MOODLE_CONF_FILE"
-        elif [[ "$MOODLE_REVERSEPROXY" != "false" ]]; then
-            warn "The allowed values for MOODLE_REVERSEPROXY are: true or false"
-        fi
-    fi
-
+    is_boolean_yes "$MOODLE_REVERSEPROXY" && echo "\$CFG->reverseproxy = true;" >> "$MOODLE_CONF_FILE"
     # Checking the sslproxy setting values
-    if ! is_empty_value "$MOODLE_SSLPROXY"; then
-        if [[ "$MOODLE_SSLPROXY" == "true" ]]; then
-            echo "\$CFG->sslproxy = true;" >> "$MOODLE_CONF_FILE"
-        elif [[ "$MOODLE_SSLPROXY" != "false" ]]; then
-            warn "The allowed values for MOODLE_SSLPROXY are: true or false"
-        fi
-    fi
+    is_boolean_yes "$MOODLE_SSLPROXY" && echo "\$CFG->sslproxy = true;" >> "$MOODLE_CONF_FILE"
 
+    true
 }

--- a/3/debian-10/rootfs/opt/bitnami/scripts/moodle-env.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/moodle-env.sh
@@ -84,8 +84,8 @@ export MOODLE_INSTALL_EXTRA_ARGS="${MOODLE_INSTALL_EXTRA_ARGS:-}" # only used du
 export MOODLE_SITE_NAME="${MOODLE_SITE_NAME:-New Site}" # only used during the first initialization
 export MOODLE_HOST="${MOODLE_HOST:-}" # only used during the first initialization
 export MOODLE_CRON_MINUTES="${MOODLE_CRON_MINUTES:-1}"
-export MOODLE_REVERSEPROXY="${MOODLE_REVERSEPROXY:-}" # only used during the first initialization
-export MOODLE_SSLPROXY="${MOODLE_SSLPROXY:-}" # only used during the first initialization
+export MOODLE_REVERSEPROXY="${MOODLE_REVERSEPROXY:-no}" # only used during the first initialization
+export MOODLE_SSLPROXY="${MOODLE_SSLPROXY:-no}" # only used during the first initialization
 
 # Moodle credentials
 export MOODLE_USERNAME="${MOODLE_USERNAME:-user}" # only used during the first initialization

--- a/3/debian-10/rootfs/opt/bitnami/scripts/moodle-env.sh
+++ b/3/debian-10/rootfs/opt/bitnami/scripts/moodle-env.sh
@@ -28,6 +28,8 @@ moodle_env_vars=(
     MOODLE_SITE_NAME
     MOODLE_HOST
     MOODLE_CRON_MINUTES
+    MOODLE_REVERSEPROXY
+    MOODLE_SSLPROXY
     MOODLE_USERNAME
     MOODLE_PASSWORD
     MOODLE_DATABASE_MIN_VERSION
@@ -82,6 +84,8 @@ export MOODLE_INSTALL_EXTRA_ARGS="${MOODLE_INSTALL_EXTRA_ARGS:-}" # only used du
 export MOODLE_SITE_NAME="${MOODLE_SITE_NAME:-New Site}" # only used during the first initialization
 export MOODLE_HOST="${MOODLE_HOST:-}" # only used during the first initialization
 export MOODLE_CRON_MINUTES="${MOODLE_CRON_MINUTES:-1}"
+export MOODLE_REVERSEPROXY="${MOODLE_REVERSEPROXY:-}" # only used during the first initialization
+export MOODLE_SSLPROXY="${MOODLE_SSLPROXY:-}" # only used during the first initialization
 
 # Moodle credentials
 export MOODLE_USERNAME="${MOODLE_USERNAME:-user}" # only used during the first initialization

--- a/README.md
+++ b/README.md
@@ -220,8 +220,10 @@ Available environment variables:
 - `MOODLE_PASSWORD`: Moodle application password. Default: **bitnami**
 - `MOODLE_EMAIL`: Moodle application email. Default: **user@example.com**
 - `MOODLE_SITE_NAME`: Moodle site name. Default: **New Site**
-- `MOODLE_SITE_NAME`: Moodle www root. No defaults.
 - `MOODLE_SKIP_BOOTSTRAP`: Do not initialize the Moodle database for a new deployment. This is necessary in case you use a database that already has Moodle data. Default: **no**
+- `MOODLE_HOST`: Allows you to configure Moodle's wwwroot feature. Ex: example.com. By default it is a PHP superglobal variable. Default: **$_SERVER['HTTP_HOST']**
+- `MOODLE_REVERSEPROXY`: Allows you to activate the reverseproxy feature of Moodle. Default: **no**
+- `MOODLE_SSLPROXY`: Allows you to activate the sslproxy feature of Moodle. Default: **no**
 
 ##### Use an existing database
 
@@ -305,6 +307,31 @@ This would be an example of SMTP configuration using a Gmail account:
     --env MOODLE_SMTP_USER=your_email@gmail.com \
     --env MOODLE_SMTP_PASSWORD=your_password \
     --env MOODLE_SMTP_PROTOCOL=tls \
+    --network moodle-tier \
+    --volume /path/to/moodle-persistence:/bitnami \
+    bitnami/moodle:latest
+  ```
+
+This would be an instance ready to be put behind the NGINX load balancer.
+
+ * Modify the [`docker-compose.yml`](https://github.com/bitnami/bitnami-docker-moodle/blob/master/docker-compose.yml) file present in this repository:
+
+```yaml
+  moodle:
+    ...
+    environment:
+      - MOODLE_HOST=example.com
+      - MOODLE_REVERSEPROXY=true
+      - MOODLE_SSLPROXY=true
+  ...
+```
+ * For manual execution:
+
+  ```console
+  $ docker run -d --name moodle -p 80:8080 -p 443:8443 \
+    --env MOODLE_HOST=example.com \
+    --env MOODLE_REVERSEPROXY=true \
+    --env MOODLE_SSLPROXY=true \
     --network moodle-tier \
     --volume /path/to/moodle-persistence:/bitnami \
     bitnami/moodle:latest


### PR DESCRIPTION
Signed-off-by: Fatih ATES <fatiiates@gmail.com>

**Description of the change**

After configure the wwwroot variable with this [PR](https://github.com/bitnami/bitnami-docker-moodle/pull/195), I came across reverseproxy. I had to manually change the $CFG->reverseproxy variable to get it behind the load balancer. But this is useless and requires you to change data in volume. I added two new environment variables named MOODLE_REVERSEPROXY and MOODLE_SSLPROXY and configured config.php with them.

**Benefits**

- REVERSEPROXY and SSLPROXY properties no longer need to be changed manually in config.php.
- Additionally, I fixed a bug that prevented the use of the MOODLE_HOST variable and updated the README by adding an example usage in the documentation.

**Possible drawbacks**

If the SSLPROXY feature is turned on, absolutely all server requests must be used with HTTPS.

**Applicable issues**

- Fixes #198 